### PR TITLE
Ps view all users

### DIFF
--- a/rareapi/views/tags.py
+++ b/rareapi/views/tags.py
@@ -93,4 +93,4 @@ class TagSerializer(serializers.ModelSerializer):
     """JSON serializer for tags"""
     class Meta:
         model = Tag
-        fields = ('id', 'author_id', 'label')
+        fields = ('id', 'author', 'label')

--- a/rareapi/views/users.py
+++ b/rareapi/views/users.py
@@ -30,7 +30,7 @@ class Users(ViewSet):
             Response -- JSON serialized list of users
         """
         # Get the current authenticated user
-        users = User.objects.all()
+        users = User.objects.all().order_by('username')
 
         serializer = UserSerializer(
             users, many=True, context={'request': request})


### PR DESCRIPTION
# Description
Users are displaying in alphabetical order, users link only appears if logged in as admin/is_staff

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
Using both client side and. server side branches, check that users link only appears when logged in as user and that users display alphabetically

1. `git fetch --all`
2. `git checkout ps-view-all-users`
3. `serve`
